### PR TITLE
Set prebuilt JS as main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quill-mention",
   "version": "2.0.6",
   "description": "@mentions for the Quill rich text editor",
-  "main": "src/quill.mention.js",
+  "main": "dist/quill.mention.min.js",
   "repository": "https://github.com/afconsult/quill-mention.git",
   "author": "Fredrik Sundqvist <fsundqvist@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Otherwise, uncompiled code gets exported and e.g. Jest cannot handle it.